### PR TITLE
fix: panic on parallel progress bar instantiation

### DIFF
--- a/internal/command/grpc_automate.go
+++ b/internal/command/grpc_automate.go
@@ -54,7 +54,7 @@ func grpcSerialFiles(workerNum int, grpcTestCases map[string][]*config.TestCaseG
 			break
 		}
 
-		info, tcResultList := HandleSingleFileGrpc(workerNum, filePath, &resource.CustomerVars)
+		info, tcResultList := HandleSingleFileGrpc(workerNum, filePath, &resource.CustomerVars, true)
 		finishCount += info.Total
 		successCount += info.SuccessCount
 		failedCount += info.FailedCount
@@ -94,7 +94,7 @@ func grpcParallelFiles(workerNum int, grpcTestCases map[string][]*config.TestCas
 		go func(fp string) {
 			// 每个文件使用独立的 vars，避免并行时变量冲突
 			fileVars := &sync.Map{}
-			info, tcResultList := HandleSingleFileGrpc(workerNum, fp, fileVars)
+			info, tcResultList := HandleSingleFileGrpc(workerNum, fp, fileVars, false)
 			resultChan <- fileResult{filePath: fp, info: info, tcResultList: tcResultList}
 		}(filePath)
 	}
@@ -131,7 +131,7 @@ func grpcParallelFiles(workerNum int, grpcTestCases map[string][]*config.TestCas
 	}
 }
 
-func HandleSingleFileGrpc(workerNum int, filePath string, vars *sync.Map) (*ResultInfo, []GrpcTestCaseResult) {
+func HandleSingleFileGrpc(workerNum int, filePath string, vars *sync.Map, showProgress bool) (*ResultInfo, []GrpcTestCaseResult) {
 	workerNum = min(workerNum, 10)
 	testcases := resource.GrpcTestCases[filePath]
 	slog.Info("[start]HandleSingleFileGrpc, filePath:%v, len(testcase):%v", filePath, len(testcases))
@@ -157,17 +157,21 @@ func HandleSingleFileGrpc(workerNum int, filePath string, vars *sync.Map) (*Resu
 		}
 	}()
 
-	p := progress.Start()
-	bar := progress.NewBar().Custom(
-		progress.BarSetting{
-			StartText:       "[",
-			EndText:         "]",
-			PassedText:      "-",
-			FirstPassedText: ">",
-			NotPassedText:   "=",
-		},
-	)
-	p.AddBar(bar)
+	var bar *progress.DefaultBar
+	var p *progress.Progress
+	if showProgress {
+		p = progress.Start()
+		bar = progress.NewBar().Custom(
+			progress.BarSetting{
+				StartText:       "[",
+				EndText:         "]",
+				PassedText:      "-",
+				FirstPassedText: ">",
+				NotPassedText:   "=",
+			},
+		)
+		p.AddBar(bar)
+	}
 
 	finishCount := 0
 	successCount := 0
@@ -212,10 +216,12 @@ func HandleSingleFileGrpc(workerNum int, filePath string, vars *sync.Map) (*Resu
 		}
 
 		finishCount++
-		// process bar will override this line.
-		fmt.Println()
-		//nolint: errcheck
-		bar.Percent(float64(finishCount) / float64(len(testcases)) * 100)
+		if showProgress {
+			// process bar will override this line.
+			fmt.Println()
+			//nolint: errcheck
+			bar.Percent(float64(finishCount) / float64(len(testcases)) * 100)
+		}
 		if finishCount >= len(testcases) {
 			// finish all test cases
 			break

--- a/internal/command/http_automate.go
+++ b/internal/command/http_automate.go
@@ -57,7 +57,7 @@ func httpSerialFiles(workerNum int, httpTestCases map[string][]*config.TestCaseH
 			break
 		}
 
-		info, tcResultList := HandleSingleFileHttp(workerNum, filePath, &resource.CustomerVars)
+		info, tcResultList := HandleSingleFileHttp(workerNum, filePath, &resource.CustomerVars, true)
 		finishCount += info.Total
 		successCount += info.SuccessCount
 		failedCount += info.FailedCount
@@ -97,7 +97,7 @@ func httpParallelFiles(workerNum int, httpTestCases map[string][]*config.TestCas
 		go func(fp string) {
 			// 每个文件使用独立的 vars，避免并行时变量冲突
 			fileVars := &sync.Map{}
-			info, tcResultList := HandleSingleFileHttp(workerNum, fp, fileVars)
+			info, tcResultList := HandleSingleFileHttp(workerNum, fp, fileVars, false)
 			resultChan <- fileResult{filePath: fp, info: info, tcResultList: tcResultList}
 		}(filePath)
 	}
@@ -228,7 +228,7 @@ func pathExists(path string) bool {
 	return !os.IsNotExist(err)
 }
 
-func HandleSingleFileHttp(workerNum int, filePath string, vars *sync.Map) (*ResultInfo, []HttpTestCaseResult) {
+func HandleSingleFileHttp(workerNum int, filePath string, vars *sync.Map, showProgress bool) (*ResultInfo, []HttpTestCaseResult) {
 	workerNum = min(workerNum, 10)
 	testcases := resource.HttpTestCases[filePath]
 	slog.Info("[start]HandleSingleFileHttp, filePath:%v, len(testcase):%v", filePath, len(testcases))
@@ -253,17 +253,21 @@ func HandleSingleFileHttp(workerNum int, filePath string, vars *sync.Map) (*Resu
 		}
 	}()
 
-	p := progress.Start()
-	bar := progress.NewBar().Custom(
-		progress.BarSetting{
-			StartText:       "[",
-			EndText:         "]",
-			PassedText:      "-",
-			FirstPassedText: ">",
-			NotPassedText:   "=",
-		},
-	)
-	p.AddBar(bar)
+	var bar *progress.DefaultBar
+	var p *progress.Progress
+	if showProgress {
+		p = progress.Start()
+		bar = progress.NewBar().Custom(
+			progress.BarSetting{
+				StartText:       "[",
+				EndText:         "]",
+				PassedText:      "-",
+				FirstPassedText: ">",
+				NotPassedText:   "=",
+			},
+		)
+		p.AddBar(bar)
+	}
 
 	finishCount := 0
 	successCount := 0
@@ -313,10 +317,12 @@ func HandleSingleFileHttp(workerNum int, filePath string, vars *sync.Map) (*Resu
 		}
 
 		finishCount++
-		// process bar will override this line.
-		fmt.Println()
-		//nolint: errcheck
-		bar.Percent(float64(finishCount) / float64(len(testcases)) * 100)
+		if showProgress {
+			// process bar will override this line.
+			fmt.Println()
+			//nolint: errcheck
+			bar.Percent(float64(finishCount) / float64(len(testcases)) * 100)
+		}
 		if finishCount >= len(testcases) {
 			// finish all test cases
 			break


### PR DESCRIPTION
Skip progress bar display when parallel_files is enabled to avoid

racing progress.Start() calls which panic due to global singleton.

Ultraworked with [Sisyphus](https://github.com/code-yeongyu/oh-my-openagent)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Progress indicators now display intelligently: visible during serial execution for real-time feedback, suppressed during parallel execution to reduce output clutter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->